### PR TITLE
refactor: svg attributes work

### DIFF
--- a/src/Hand.tsx
+++ b/src/Hand.tsx
@@ -13,7 +13,7 @@ export const Hand = ({
 }: HandProps): JSX.Element => (
   <line
     class={['stroke-cap-round', clazz]}
-    {...(stationary && { y1: length - limit })}
+    y1={stationary ? length - limit : undefined}
     y2={-(stationary ? limit : length)}
     {...rest}
   />


### PR DESCRIPTION
- setting svg attribute to undefined removes it from DOM in 0.42.3, so used that for y1 Hand attribute